### PR TITLE
feat: リポジトリURL入力画面の作成

### DIFF
--- a/GitTale/ContentView.swift
+++ b/GitTale/ContentView.swift
@@ -9,13 +9,7 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
-        }
-        .padding()
+        RepositoryInputView()
     }
 }
 

--- a/GitTale/Views/RepositoryInputView.swift
+++ b/GitTale/Views/RepositoryInputView.swift
@@ -1,0 +1,200 @@
+//
+//  RepositoryInputView.swift
+//  GitTale
+//
+//  Created by ogatomo83 on 2026/01/11.
+//
+
+import SwiftUI
+
+/// 仮のリポジトリデータ（後でModelに移動）
+struct Repository: Identifiable, Hashable {
+    let id = UUID()
+    let name: String
+    let url: String
+    let clonedAt: Date?
+}
+
+struct RepositoryInputView: View {
+    @State private var repositories: [Repository] = []
+    @State private var selectedRepository: Repository?
+    @State private var newRepositoryURL: String = ""
+    @State private var isCloning: Bool = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationSplitView {
+            // Sidebar: リポジトリ一覧
+            List(selection: $selectedRepository) {
+                Section("リポジトリ一覧") {
+                    ForEach(repositories) { repo in
+                        RepositoryRow(repository: repo)
+                            .tag(repo)
+                    }
+                }
+            }
+            .listStyle(.sidebar)
+            .frame(minWidth: 200)
+            .toolbar {
+                ToolbarItem {
+                    Button(action: { selectedRepository = nil }) {
+                        Image(systemName: "plus")
+                    }
+                    .help("新しいリポジトリを追加")
+                }
+            }
+            .navigationSplitViewColumnWidth(min: 200, ideal: 250)
+        } detail: {
+            // Detail: 選択中のリポジトリ or 新規追加フォーム
+            if let repo = selectedRepository {
+                RepositoryDetailView(repository: repo)
+            } else {
+                AddRepositoryView(
+                    repositoryURL: $newRepositoryURL,
+                    isCloning: $isCloning,
+                    errorMessage: $errorMessage,
+                    onClone: cloneRepository
+                )
+            }
+        }
+        .navigationTitle("GitTale")
+    }
+
+    private func cloneRepository() {
+        guard !newRepositoryURL.isEmpty else { return }
+
+        isCloning = true
+        errorMessage = nil
+
+        // TODO: Implement actual clone logic
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            // 仮実装: リポジトリ名を抽出して一覧に追加
+            let repoName = extractRepositoryName(from: newRepositoryURL)
+            let newRepo = Repository(name: repoName, url: newRepositoryURL, clonedAt: Date())
+            repositories.append(newRepo)
+            selectedRepository = newRepo
+            newRepositoryURL = ""
+            isCloning = false
+        }
+    }
+
+    private func extractRepositoryName(from url: String) -> String {
+        // URLからリポジトリ名を抽出
+        let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
+        let withoutGit = trimmed.hasSuffix(".git") ? String(trimmed.dropLast(4)) : trimmed
+        return withoutGit.components(separatedBy: "/").last ?? "Unknown"
+    }
+}
+
+// MARK: - Subviews
+
+struct RepositoryRow: View {
+    let repository: Repository
+
+    var body: some View {
+        HStack {
+            Image(systemName: "folder.fill")
+                .foregroundStyle(.blue)
+            VStack(alignment: .leading) {
+                Text(repository.name)
+                    .font(.body)
+                if let date = repository.clonedAt {
+                    Text(date, format: .relative(presentation: .named))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+struct AddRepositoryView: View {
+    @Binding var repositoryURL: String
+    @Binding var isCloning: Bool
+    @Binding var errorMessage: String?
+    let onClone: () -> Void
+
+    var body: some View {
+        VStack(spacing: 24) {
+            // Header
+            VStack(spacing: 12) {
+                Image(systemName: "plus.circle")
+                    .font(.system(size: 48))
+                    .foregroundStyle(.blue)
+
+                Text("新しいリポジトリを追加")
+                    .font(.title2)
+                    .fontWeight(.semibold)
+            }
+
+            // URL Input
+            VStack(spacing: 12) {
+                TextField("https://github.com/user/repository.git", text: $repositoryURL)
+                    .textFieldStyle(.roundedBorder)
+                    .frame(maxWidth: 400)
+                    .disabled(isCloning)
+
+                Button(action: onClone) {
+                    if isCloning {
+                        HStack {
+                            ProgressView()
+                                .scaleEffect(0.8)
+                            Text("Cloning...")
+                        }
+                        .frame(width: 120)
+                    } else {
+                        Text("Clone")
+                            .frame(width: 120)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(repositoryURL.isEmpty || isCloning)
+
+                if let error = errorMessage {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                }
+            }
+
+            // Help
+            Text("GitHub、GitLab等のリポジトリURLを入力してください")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+struct RepositoryDetailView: View {
+    let repository: Repository
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "book.pages")
+                .font(.system(size: 48))
+                .foregroundStyle(.secondary)
+
+            Text(repository.name)
+                .font(.title)
+                .fontWeight(.bold)
+
+            Text(repository.url)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .monospaced()
+
+            Divider()
+                .padding(.horizontal, 40)
+
+            Text("コミット履歴の表示は次のissueで実装予定です")
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+}
+
+#Preview {
+    RepositoryInputView()
+}

--- a/docs/01-PRD.md
+++ b/docs/01-PRD.md
@@ -50,10 +50,11 @@ Gitリポジトリのコミットログを、AIの力で意味のある「開発
 ### 2.1 MV（Minimum Viable）機能
 
 #### FR-001: リポジトリ操作
-- **FR-001-01**: ローカルGitリポジトリをドラッグ&ドロップで開く
-- **FR-001-02**: 最近開いたリポジトリの履歴表示（UserDefaults）
-- **FR-001-03**: `git log --reverse --all` でコミット履歴取得
-- **FR-001-04**: `git checkout` で任意のコミットに移動（読み取り専用モード）
+- **FR-001-01**: リポジトリURL（GitHub等）を指定して `git clone` で自動取得
+- **FR-001-02**: クローン先は設定可能なソースディレクトリ（デフォルト: `$HOME/GitTaleSourceDir/{repository_name}`）
+- **FR-001-03**: 最近開いたリポジトリの履歴表示（UserDefaults）
+- **FR-001-04**: `git log --reverse --all` でコミット履歴取得（最初のコミットから順に）
+- **FR-001-05**: `git checkout` で任意のコミットに移動し、その時点のコードを参照可能
 
 #### FR-002: コミット解析
 - **FR-002-01**: `git log --format` でコミット情報抽出（SHA, Author, Date, Message, Parents）
@@ -175,20 +176,21 @@ struct DiffMetadata {
 ### 5.1 ディレクトリ構造
 
 ```
-/path/to/repository/
-├── .git/                    # Git本体（読み取りのみ）
-├── .gittale/                # GitTaleキャッシュ
-│   ├── .gitignore           # "**" で全体を無視
-│   └── cache/
-│       ├── commits/
-│       │   ├── abc1234.json # 個別コミット要約
-│       │   └── def5678.json
-│       ├── groups/
-│       │   └── 2024-w03.json # 週間グループ要約
-│       ├── versions/
-│       │   └── v1.0.0.json  # バージョン要約
-│       └── story.json       # プロジェクト全体ストーリー
-└── src/                     # 実際のソースコード
+$HOME/GitTaleSourceDir/          # アプリ設定で変更可能なソースディレクトリ
+└── {repository_name}/           # クローンしたリポジトリ
+    ├── .git/                    # Git本体（読み取りのみ）
+    ├── .gittale/                # GitTaleキャッシュ
+    │   ├── .gitignore           # "**" で全体を無視
+    │   └── cache/
+    │       ├── commits/
+    │       │   ├── abc1234.json # 個別コミット要約
+    │       │   └── def5678.json
+    │       ├── groups/
+    │       │   └── 2024-w03.json # 週間グループ要約
+    │       ├── versions/
+    │       │   └── v1.0.0.json  # バージョン要約
+    │       └── story.json       # プロジェクト全体ストーリー
+    └── src/                     # 実際のソースコード
 ```
 
 ### 5.2 キャッシュ無効化
@@ -222,12 +224,13 @@ func ensureGitIgnore(in gittaleDir: URL) {
 ## 6. 制約事項
 
 ### 6.1 スコープ内
-- ローカルGitリポジトリの解析
+- リモートリポジトリURLからの自動クローン
+- クローンしたリポジトリの解析
+- 最初のコミットから順にコードの歴史を追跡
 - AI要約の生成とキャッシュ
-- 読み取り専用の履歴閲覧
+- 任意のコミット時点のコード参照
 
 ### 6.2 スコープ外
-- リモートリポジトリの直接クローン
 - コード編集・コミット作成
 - Windows/Linux対応
 - リアルタイムコラボレーション


### PR DESCRIPTION
## Summary

- 複数のOSSリポジトリを並行管理できるUIを実装
- NavigationSplitViewによる2カラム構成（サイドバー + 詳細エリア）

## 実装内容

### 新規ファイル
- `GitTale/Views/RepositoryInputView.swift`
  - `Repository` 構造体（仮実装、後でModel層に移動予定）
  - `RepositoryInputView` - メインビュー（NavigationSplitView）
  - `RepositoryRow` - サイドバーのリポジトリ行
  - `AddRepositoryView` - 新規リポジトリ追加フォーム
  - `RepositoryDetailView` - リポジトリ詳細表示

### 変更ファイル
- `GitTale/ContentView.swift` - RepositoryInputViewを表示するよう変更
- `docs/01-PRD.md` - 仕様を修正（リモートリポジトリのクローン対応）

### UI構成
```
┌─────────────────┬──────────────────────────────┐
│ リポジトリ一覧    │  詳細 / 新規追加フォーム      │
│                 │                              │
│ [+] ボタン       │  - リポジトリ選択時: 詳細表示  │
│                 │  - 未選択時: URL入力フォーム   │
│ ├ repo1         │                              │
│ └ repo2         │                              │
└─────────────────┴──────────────────────────────┘
```

## 今後の課題
- 実際のgit clone処理の実装（次のissueで対応）
- Repository構造体のModel層への移動
- リポジトリの永続化（UserDefaults）

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)