### PR TITLE
feat: 設定画面の作成（Working Directory設定）

### DIFF
--- a/GitTale/GitTaleApp.swift
+++ b/GitTale/GitTaleApp.swift
@@ -9,9 +9,17 @@ import SwiftUI
 
 @main
 struct GitTaleApp: App {
+    init() {
+        AppSettings.shared.resetInvalidPathIfNeeded()
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()
+        }
+
+        Settings {
+            SettingsView()
         }
     }
 }

--- a/GitTale/Models/AppSettings.swift
+++ b/GitTale/Models/AppSettings.swift
@@ -1,0 +1,128 @@
+//
+//  AppSettings.swift
+//  GitTale
+//
+//  Created by ogatomo83 on 2026/01/11.
+//
+
+import Foundation
+import SwiftUI
+
+@Observable
+final class AppSettings {
+    static let shared = AppSettings()
+
+    private let defaults = UserDefaults.standard
+
+    // MARK: - Keys
+    private enum Keys {
+        static let workingDirectory = "workingDirectory"
+    }
+
+    // MARK: - Working Directory
+
+    /// ベースディレクトリ（~/.GitTale）
+    var workingDirectory: String {
+        get {
+            defaults.string(forKey: Keys.workingDirectory) ?? defaultWorkingDirectory
+        }
+        set {
+            defaults.set(newValue, forKey: Keys.workingDirectory)
+        }
+    }
+
+    /// デフォルトのWorking Directory（~/.GitTale）
+    var defaultWorkingDirectory: String {
+        return realHomeDirectory.appendingPathComponent(".GitTale").path
+    }
+
+    /// 実際のホームディレクトリを取得（サンドボックス回避）
+    /// SandBoxアプリではNSHomeDirectory()が使えないため、getpwuid(getuid())を使用
+    private var realHomeDirectory: URL {
+        guard let pw = getpwuid(getuid()),
+              let homeDir = pw.pointee.pw_dir else {
+            // フォールバック（通常はここには来ない）
+            return FileManager.default.homeDirectoryForCurrentUser
+        }
+        return URL(fileURLWithPath: String(cString: homeDir))
+    }
+
+    /// UserDefaultsに保存された値が不正（サンドボックス内等）の場合はリセット
+    func resetInvalidPathIfNeeded() {
+        if let saved = defaults.string(forKey: Keys.workingDirectory),
+           saved.contains("Containers") {
+            defaults.removeObject(forKey: Keys.workingDirectory)
+        }
+    }
+
+    /// Working DirectoryのURLを取得
+    var workingDirectoryURL: URL {
+        URL(fileURLWithPath: workingDirectory)
+    }
+
+    // MARK: - Directory Structure
+
+    /// リポジトリ格納ディレクトリ（~/.GitTale/repositories）
+    var repositoriesDirectoryURL: URL {
+        workingDirectoryURL.appendingPathComponent("repositories")
+    }
+
+    /// キャッシュディレクトリ（~/.GitTale/cache）
+    var cacheDirectoryURL: URL {
+        workingDirectoryURL.appendingPathComponent("cache")
+    }
+
+    /// 特定リポジトリのディレクトリを取得（~/.GitTale/repositories/{owner}/{name}）
+    func repositoryDirectoryURL(owner: String, name: String) -> URL {
+        repositoriesDirectoryURL
+            .appendingPathComponent(owner)
+            .appendingPathComponent(name)
+    }
+
+    /// 特定リポジトリのメタデータJSONパス
+    func repositoryMetadataURL(owner: String, name: String) -> URL {
+        repositoryDirectoryURL(owner: owner, name: name)
+            .appendingPathComponent("\(name).json")
+    }
+
+    /// 特定リポジトリのソースコードディレクトリ
+    func repositorySourceURL(owner: String, name: String) -> URL {
+        repositoryDirectoryURL(owner: owner, name: name)
+            .appendingPathComponent("source")
+    }
+
+    // MARK: - Directory Setup
+
+    /// 必要なディレクトリ構造を作成
+    func ensureDirectoryStructureExists() throws {
+        let fileManager = FileManager.default
+
+        let directories = [
+            workingDirectoryURL,
+            repositoriesDirectoryURL,
+            cacheDirectoryURL
+        ]
+
+        for directory in directories {
+            if !fileManager.fileExists(atPath: directory.path) {
+                try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            }
+        }
+    }
+
+    /// 特定リポジトリ用のディレクトリを作成
+    func ensureRepositoryDirectoryExists(owner: String, name: String) throws {
+        let fileManager = FileManager.default
+        let repoDir = repositoryDirectoryURL(owner: owner, name: name)
+        let sourceDir = repositorySourceURL(owner: owner, name: name)
+
+        if !fileManager.fileExists(atPath: repoDir.path) {
+            try fileManager.createDirectory(at: repoDir, withIntermediateDirectories: true)
+        }
+        if !fileManager.fileExists(atPath: sourceDir.path) {
+            try fileManager.createDirectory(at: sourceDir, withIntermediateDirectories: true)
+        }
+    }
+
+    private init() {}
+}

--- a/GitTale/Views/RepositoryInputView.swift
+++ b/GitTale/Views/RepositoryInputView.swift
@@ -16,6 +16,7 @@ struct Repository: Identifiable, Hashable {
 }
 
 struct RepositoryInputView: View {
+    @Environment(\.openSettings) private var openSettings
     @State private var repositories: [Repository] = []
     @State private var selectedRepository: Repository?
     @State private var newRepositoryURL: String = ""
@@ -42,6 +43,18 @@ struct RepositoryInputView: View {
                     }
                     .help("新しいリポジトリを追加")
                 }
+            }
+            .safeAreaInset(edge: .bottom) {
+                HStack {
+                    Button(action: { openSettings() }) {
+                        Image(systemName: "gear")
+                    }
+                    .buttonStyle(.plain)
+                    .help("設定")
+
+                    Spacer()
+                }
+                .padding(12)
             }
             .navigationSplitViewColumnWidth(min: 200, ideal: 250)
         } detail: {

--- a/GitTale/Views/SettingsView.swift
+++ b/GitTale/Views/SettingsView.swift
@@ -1,0 +1,80 @@
+//
+//  SettingsView.swift
+//  GitTale
+//
+//  Created by ogatomo83 on 2026/01/11.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    @State private var settings = AppSettings.shared
+    @State private var workingDirectoryInput: String = ""
+    @State private var showDirectoryPicker = false
+
+    var body: some View {
+        Form {
+            Section {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Working Directory")
+                        .font(.headline)
+
+                    Text("リポジトリのクローン先ディレクトリを指定します")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    HStack {
+                        TextField("", text: $workingDirectoryInput, prompt: Text("/Users/.../.GitTale"))
+                            .textFieldStyle(.roundedBorder)
+                            .labelsHidden()
+
+                        Button("選択...") {
+                            showDirectoryPicker = true
+                        }
+
+                        Button("デフォルトに戻す") {
+                            workingDirectoryInput = settings.defaultWorkingDirectory
+                            settings.workingDirectory = workingDirectoryInput
+                        }
+                        .foregroundStyle(.secondary)
+                    }
+
+                    Text("現在: \(settings.workingDirectory)")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                        .monospaced()
+                }
+                .padding(.vertical, 8)
+            } header: {
+                Label("ストレージ", systemImage: "folder")
+            }
+        }
+        .formStyle(.grouped)
+        .frame(width: 500, height: 200)
+        .onAppear {
+            workingDirectoryInput = settings.workingDirectory
+        }
+        .onChange(of: workingDirectoryInput) { _, newValue in
+            settings.workingDirectory = newValue
+        }
+        .fileImporter(
+            isPresented: $showDirectoryPicker,
+            allowedContentTypes: [.folder],
+            allowsMultipleSelection: false
+        ) { result in
+            switch result {
+            case .success(let urls):
+                if let url = urls.first {
+                    workingDirectoryInput = url.path
+                    settings.workingDirectory = url.path
+                }
+            case .failure(let error):
+                print("Directory picker error: \(error)")
+            }
+        }
+    }
+}
+
+#Preview {
+    SettingsView()
+}

--- a/docs/01-PRD.md
+++ b/docs/01-PRD.md
@@ -176,21 +176,27 @@ struct DiffMetadata {
 ### 5.1 ディレクトリ構造
 
 ```
-$HOME/GitTaleSourceDir/          # アプリ設定で変更可能なソースディレクトリ
-└── {repository_name}/           # クローンしたリポジトリ
-    ├── .git/                    # Git本体（読み取りのみ）
-    ├── .gittale/                # GitTaleキャッシュ
-    │   ├── .gitignore           # "**" で全体を無視
-    │   └── cache/
-    │       ├── commits/
-    │       │   ├── abc1234.json # 個別コミット要約
-    │       │   └── def5678.json
-    │       ├── groups/
-    │       │   └── 2024-w03.json # 週間グループ要約
-    │       ├── versions/
-    │       │   └── v1.0.0.json  # バージョン要約
-    │       └── story.json       # プロジェクト全体ストーリー
-    └── src/                     # 実際のソースコード
+~/.GitTale/                          # アプリのベースディレクトリ（設定で変更可能）
+├── repositories/                    # リポジトリ格納ディレクトリ
+│   ├── rails/                       # owner名
+│   │   └── rails/                   # repository名
+│   │       ├── rails.json           # リポジトリメタデータ（URL, clonedAt等）
+│   │       └── source/              # クローンしたソースコード
+│   │           ├── .git/
+│   │           └── ...
+│   └── nodejs/
+│       └── node/
+│           ├── node.json
+│           └── source/
+└── cache/                           # AI要約キャッシュ
+    ├── commits/
+    │   ├── abc1234.json             # 個別コミット要約
+    │   └── def5678.json
+    ├── groups/
+    │   └── 2024-w03.json            # 週間グループ要約
+    ├── versions/
+    │   └── v1.0.0.json              # バージョン要約
+    └── story.json                   # プロジェクト全体ストーリー
 ```
 
 ### 5.2 キャッシュ無効化


### PR DESCRIPTION
## Summary

- 設定画面を追加し、Working Directoryを設定できるようにした
- サイドバーに歯車ボタンを追加し、設定画面へアクセス可能に
- PRDのディレクトリ構造を更新

## 実装内容

### 新規ファイル
- `GitTale/Models/AppSettings.swift`
  - UserDefaultsでの設定永続化
  - ディレクトリ構造管理（`~/.GitTale/repositories/`, `cache/`）
  - `getpwuid(getuid())`でサンドボックス回避し実際のホームディレクトリを取得
  - 不正なパス（サンドボックス内）の自動リセット機能

- `GitTale/Views/SettingsView.swift`
  - Working Directory設定UI
  - ディレクトリ選択ダイアログ
  - デフォルトに戻すボタン

### 変更ファイル
- `GitTale/GitTaleApp.swift` - Settings シーン追加、起動時のパスリセット
- `GitTale/Views/RepositoryInputView.swift` - サイドバーに設定ボタン追加
- `docs/01-PRD.md` - ディレクトリ構造を更新

### ディレクトリ構造
```
~/.GitTale/
├── repositories/
│   └── {owner}/{name}/
│       ├── {name}.json    # メタデータ
│       └── source/        # クローンしたソース
└── cache/                 # AI要約キャッシュ
```

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/code)