### PR TITLE
feat: git clone機能の実装

### DIFF
--- a/GitTale/GitTale.entitlements
+++ b/GitTale/GitTale.entitlements
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>com.apple.security.app-sandbox</key>
-	<true/>
-	<key>com.apple.security.files.user-selected.read-only</key>
-	<true/>
-</dict>
+<dict/>
 </plist>

--- a/GitTale/Models/Repository.swift
+++ b/GitTale/Models/Repository.swift
@@ -1,0 +1,124 @@
+//
+//  Repository.swift
+//  GitTale
+//
+//  Created by ogatomo83 on 2026/01/11.
+//
+
+import Foundation
+
+/// リポジトリ情報
+struct Repository: Identifiable, Hashable, Codable {
+    let id: UUID
+    let owner: String
+    let name: String
+    let url: String
+    let clonedAt: Date
+
+    init(id: UUID = UUID(), owner: String, name: String, url: String, clonedAt: Date = Date()) {
+        self.id = id
+        self.owner = owner
+        self.name = name
+        self.url = url
+        self.clonedAt = clonedAt
+    }
+
+    /// 表示用の名前（owner/name）
+    var displayName: String {
+        "\(owner)/\(name)"
+    }
+}
+
+// MARK: - Repository Storage
+
+/// リポジトリの永続化を管理
+actor RepositoryStorage {
+    static let shared = RepositoryStorage()
+
+    private let settings = AppSettings.shared
+
+    private init() {}
+
+    // MARK: - Save
+
+    /// リポジトリのメタデータをJSONファイルに保存
+    func save(_ repository: Repository) throws {
+        let metadataURL = settings.repositoryMetadataURL(owner: repository.owner, name: repository.name)
+
+        // ディレクトリが存在しない場合は作成
+        let directory = metadataURL.deletingLastPathComponent()
+        if !FileManager.default.fileExists(atPath: directory.path) {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        encoder.dateEncodingStrategy = .iso8601
+
+        let data = try encoder.encode(repository)
+        try data.write(to: metadataURL)
+    }
+
+    // MARK: - Load
+
+    /// 全てのリポジトリを読み込む
+    func loadAll() throws -> [Repository] {
+        let repositoriesDir = settings.repositoriesDirectoryURL
+        let fileManager = FileManager.default
+
+        guard fileManager.fileExists(atPath: repositoriesDir.path) else {
+            return []
+        }
+
+        var repositories: [Repository] = []
+
+        // owner ディレクトリを列挙
+        let ownerDirs = try fileManager.contentsOfDirectory(at: repositoriesDir, includingPropertiesForKeys: nil)
+
+        for ownerDir in ownerDirs {
+            guard ownerDir.hasDirectoryPath else { continue }
+
+            // name ディレクトリを列挙
+            let nameDirs = try fileManager.contentsOfDirectory(at: ownerDir, includingPropertiesForKeys: nil)
+
+            for nameDir in nameDirs {
+                guard nameDir.hasDirectoryPath else { continue }
+
+                // {name}.json を探す
+                let jsonFile = nameDir.appendingPathComponent("\(nameDir.lastPathComponent).json")
+
+                if fileManager.fileExists(atPath: jsonFile.path) {
+                    if let repo = try? loadRepository(from: jsonFile) {
+                        repositories.append(repo)
+                    }
+                }
+            }
+        }
+
+        return repositories.sorted { $0.clonedAt > $1.clonedAt }
+    }
+
+    /// 特定のJSONファイルからリポジトリを読み込む
+    private func loadRepository(from url: URL) throws -> Repository {
+        let data = try Data(contentsOf: url)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(Repository.self, from: data)
+    }
+
+    // MARK: - Delete
+
+    /// リポジトリを削除
+    func delete(_ repository: Repository) throws {
+        let repoDir = settings.repositoryDirectoryURL(owner: repository.owner, name: repository.name)
+        try FileManager.default.removeItem(at: repoDir)
+    }
+
+    // MARK: - Check
+
+    /// リポジトリが既に存在するか確認
+    func exists(owner: String, name: String) -> Bool {
+        let sourceDir = settings.repositorySourceURL(owner: owner, name: name)
+        return FileManager.default.fileExists(atPath: sourceDir.path)
+    }
+}

--- a/GitTale/Services/GitService.swift
+++ b/GitTale/Services/GitService.swift
@@ -1,0 +1,112 @@
+//
+//  GitService.swift
+//  GitTale
+//
+//  Created by ogatomo83 on 2026/01/11.
+//
+
+import Foundation
+
+/// Gitコマンドを実行するサービス
+actor GitService {
+    static let shared = GitService()
+
+    private init() {}
+
+    // MARK: - Clone
+
+    /// リポジトリをクローンする
+    /// - Parameters:
+    ///   - url: リポジトリURL
+    ///   - destination: クローン先ディレクトリ
+    /// - Returns: 成功時はtrue
+    func clone(url: String, to destination: URL) async throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        process.arguments = ["clone", url, destination.path]
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        try process.run()
+        process.waitUntilExit()
+
+        if process.terminationStatus != 0 {
+            let errorData = stderr.fileHandleForReading.readDataToEndOfFile()
+            let errorMessage = String(data: errorData, encoding: .utf8) ?? "Unknown error"
+            throw GitError.cloneFailed(errorMessage)
+        }
+    }
+
+    // MARK: - Repository Validation
+
+    /// URLからリポジトリ情報を解析
+    /// - Parameter url: リポジトリURL (例: https://github.com/owner/repo.git)
+    /// - Returns: (owner, name) のタプル
+    func parseRepositoryURL(_ url: String) throws -> (owner: String, name: String) {
+        // GitHub, GitLab, Bitbucket などに対応
+        // 形式: https://github.com/owner/repo.git または git@github.com:owner/repo.git
+
+        let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        // .git 拡張子を削除
+        let withoutGit = trimmed.hasSuffix(".git") ? String(trimmed.dropLast(4)) : trimmed
+
+        // HTTPS形式: https://github.com/owner/repo
+        if withoutGit.contains("://") {
+            let components = withoutGit.components(separatedBy: "/")
+            guard components.count >= 2 else {
+                throw GitError.invalidURL(url)
+            }
+            let name = components.last ?? ""
+            let owner = components.dropLast().last ?? ""
+
+            guard !owner.isEmpty, !name.isEmpty else {
+                throw GitError.invalidURL(url)
+            }
+            return (owner, name)
+        }
+
+        // SSH形式: git@github.com:owner/repo
+        if withoutGit.contains("@") && withoutGit.contains(":") {
+            let afterColon = withoutGit.components(separatedBy: ":").last ?? ""
+            let parts = afterColon.components(separatedBy: "/")
+            guard parts.count >= 2 else {
+                throw GitError.invalidURL(url)
+            }
+            let owner = parts[0]
+            let name = parts[1]
+
+            guard !owner.isEmpty, !name.isEmpty else {
+                throw GitError.invalidURL(url)
+            }
+            return (owner, name)
+        }
+
+        throw GitError.invalidURL(url)
+    }
+}
+
+// MARK: - Errors
+
+enum GitError: LocalizedError {
+    case cloneFailed(String)
+    case invalidURL(String)
+    case notARepository
+    case commandFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .cloneFailed(let message):
+            return "Clone failed: \(message)"
+        case .invalidURL(let url):
+            return "Invalid repository URL: \(url)"
+        case .notARepository:
+            return "Not a Git repository"
+        case .commandFailed(let message):
+            return "Git command failed: \(message)"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- リポジトリURLを入力してgit cloneを実行する機能を実装
- クローンしたリポジトリのメタデータをJSON形式で保存
- 起動時に保存済みリポジトリを読み込み

## 実装内容

### 新規ファイル
- `GitTale/Services/GitService.swift`
  - `clone(url:to:)` - git clone実行
  - `parseRepositoryURL(_:)` - URLからowner/nameを解析（HTTPS, SSH形式対応）

- `GitTale/Models/Repository.swift`
  - `Repository` - リポジトリモデル（Codable対応）
  - `RepositoryStorage` - JSON保存/読み込み、重複チェック

### 変更ファイル
- `GitTale/Views/RepositoryInputView.swift` - 実際のcloneロジックを実装
- `GitTale/GitTale.entitlements` - App Sandbox無効化（git実行のため）

### 動作フロー
1. URLを入力してCloneボタン押下
2. URLを解析してowner/nameを取得
3. `~/.GitTale/repositories/{owner}/{name}/source/` にクローン
4. `{name}.json` にメタデータを保存
5. サイドバーに追加

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)