### PR TITLE
feat: コミット差分ビューア機能を実装 (#11)

### DIFF
--- a/GitTale/GitTaleApp.swift
+++ b/GitTale/GitTaleApp.swift
@@ -18,8 +18,33 @@ struct GitTaleApp: App {
             ContentView()
         }
 
+        // 差分ビューアウィンドウ
+        WindowGroup(id: "diff-viewer", for: DiffViewerData.self) { $data in
+            if let data = data {
+                DiffViewerView(
+                    context: DiffContext(
+                        repository: data.repository,
+                        commits: data.commits,
+                        browseMode: data.browseMode
+                    )
+                )
+            } else {
+                Text("データがありません")
+            }
+        }
+        .defaultSize(width: 1000, height: 700)
+
         Settings {
             SettingsView()
         }
     }
+}
+
+// MARK: - Diff Viewer Data
+
+/// 差分ビューアに渡すデータ
+struct DiffViewerData: Codable, Hashable {
+    let repository: Repository
+    let commits: [Commit]
+    var browseMode: Bool = false  // true: ファイル閲覧モード（差分なし）
 }

--- a/GitTale/Models/Commit.swift
+++ b/GitTale/Models/Commit.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Gitコミット情報
-struct Commit: Identifiable, Hashable {
+struct Commit: Identifiable, Hashable, Codable {
     let sha: String
     let shortSHA: String
     let author: String
@@ -28,16 +28,23 @@ struct Commit: Identifiable, Hashable {
     var isMergeCommit: Bool {
         parentSHAs.count > 1
     }
+
+    // Codable: computedプロパティを除外
+    enum CodingKeys: String, CodingKey {
+        case sha, shortSHA, author, email, date, message, parentSHAs
+    }
 }
 
 /// リポジトリの進捗状況
 struct RepositoryProgress: Codable {
     var checkedCommitSHAs: Set<String>
     var lastUpdated: Date
+    var currentCheckoutSHA: String?  // 現在チェックアウト中のSHA
 
-    init(checkedCommitSHAs: Set<String> = [], lastUpdated: Date = Date()) {
+    init(checkedCommitSHAs: Set<String> = [], lastUpdated: Date = Date(), currentCheckoutSHA: String? = nil) {
         self.checkedCommitSHAs = checkedCommitSHAs
         self.lastUpdated = lastUpdated
+        self.currentCheckoutSHA = currentCheckoutSHA
     }
 
     /// コミットが確認済みかどうか
@@ -52,6 +59,12 @@ struct RepositoryProgress: Codable {
         } else {
             checkedCommitSHAs.insert(sha)
         }
+        lastUpdated = Date()
+    }
+
+    /// チェックアウト状態を更新
+    mutating func setCheckout(_ sha: String?) {
+        currentCheckoutSHA = sha
         lastUpdated = Date()
     }
 }

--- a/GitTale/Models/Diff.swift
+++ b/GitTale/Models/Diff.swift
@@ -1,0 +1,443 @@
+//
+//  Diff.swift
+//  GitTale
+//
+//  Created by ogatomo83 on 2026/01/12.
+//
+
+import SwiftUI
+
+// MARK: - File Tree Node
+
+/// ファイルツリーのノード
+class FileTreeNode: Identifiable, ObservableObject {
+    let id = UUID()
+    let name: String
+    let path: String
+    let isDirectory: Bool
+    var changeStatus: ChangeStatus?
+    @Published var children: [FileTreeNode]
+    @Published var isExpanded: Bool
+
+    init(name: String, path: String, isDirectory: Bool, children: [FileTreeNode] = []) {
+        self.name = name
+        self.path = path
+        self.isDirectory = isDirectory
+        self.children = children
+        self.isExpanded = false
+        self.changeStatus = nil
+    }
+
+    /// フラットなファイルパスリストからツリーを構築
+    static func buildTree(from paths: [String], changedFiles: [ChangedFile] = []) -> [FileTreeNode] {
+        // 変更ステータスのマップ
+        let changedPathsStatus = Dictionary(uniqueKeysWithValues: changedFiles.map { ($0.path, $0.status) })
+
+        // ルートレベルのノードマップ
+        var rootNodes: [String: FileTreeNode] = [:]
+
+        for path in paths {
+            let components = path.components(separatedBy: "/")
+            var currentNodes = rootNodes
+            var currentPath = ""
+            var parentNode: FileTreeNode?
+
+            for (index, component) in components.enumerated() {
+                let isLast = index == components.count - 1
+                currentPath = currentPath.isEmpty ? component : "\(currentPath)/\(component)"
+
+                // 既存ノードを探すか、新規作成
+                let node: FileTreeNode
+                if let existingNode = currentNodes[component] {
+                    node = existingNode
+                } else {
+                    node = FileTreeNode(
+                        name: component,
+                        path: currentPath,
+                        isDirectory: !isLast
+                    )
+
+                    // ファイルの場合は変更ステータスを設定
+                    if isLast {
+                        node.changeStatus = changedPathsStatus[path]
+                    }
+
+                    // 親に追加またはルートに追加
+                    if let parent = parentNode {
+                        parent.children.append(node)
+                    } else {
+                        rootNodes[component] = node
+                    }
+                }
+
+                // ディレクトリの場合は子ノードマップを更新
+                if !isLast {
+                    // 子ノードをマップに変換
+                    var childMap: [String: FileTreeNode] = [:]
+                    for child in node.children {
+                        childMap[child.name] = child
+                    }
+                    currentNodes = childMap
+                    parentNode = node
+                }
+            }
+        }
+
+        // ルートノードを配列に変換してソート
+        return sortNodes(Array(rootNodes.values))
+    }
+
+    /// ノードをソート（ディレクトリ優先、名前順）
+    static func sortNodes(_ nodes: [FileTreeNode]) -> [FileTreeNode] {
+        nodes.sorted { lhs, rhs in
+            if lhs.isDirectory != rhs.isDirectory {
+                return lhs.isDirectory
+            }
+            return lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+        }.map { node in
+            if node.isDirectory && !node.children.isEmpty {
+                node.children = sortNodes(node.children)
+            }
+            return node
+        }
+    }
+
+    /// ディレクトリが変更されたファイルを含むかどうか
+    var hasChangedDescendant: Bool {
+        if changeStatus != nil { return true }
+        return children.contains { $0.hasChangedDescendant }
+    }
+
+    /// ディレクトリの変更ステータス（子の変更を反映）
+    var effectiveChangeStatus: ChangeStatus? {
+        if changeStatus != nil { return changeStatus }
+        if isDirectory && hasChangedDescendant {
+            // 子の中で最も優先度が高いステータスを返す
+            let childStatuses = children.compactMap { $0.effectiveChangeStatus }
+            if childStatuses.contains(.added) { return .added }
+            if childStatuses.contains(.deleted) { return .deleted }
+            if childStatuses.contains(.modified) { return .modified }
+        }
+        return nil
+    }
+}
+
+// MARK: - Changed File
+
+/// 変更されたファイル
+struct ChangedFile: Identifiable, Hashable {
+    let path: String
+    let status: ChangeStatus
+
+    var id: String { path }
+
+    /// ファイル名のみ
+    var fileName: String {
+        (path as NSString).lastPathComponent
+    }
+
+    /// ディレクトリパス
+    var directory: String {
+        (path as NSString).deletingLastPathComponent
+    }
+}
+
+/// ファイルの変更ステータス
+enum ChangeStatus: String {
+    case added = "A"
+    case modified = "M"
+    case deleted = "D"
+    case renamed = "R"
+    case copied = "C"
+
+    var color: Color {
+        switch self {
+        case .added: return .green
+        case .modified: return .yellow
+        case .deleted: return .red
+        case .renamed: return .blue
+        case .copied: return .purple
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .added: return "plus.circle.fill"
+        case .modified: return "pencil.circle.fill"
+        case .deleted: return "minus.circle.fill"
+        case .renamed: return "arrow.right.circle.fill"
+        case .copied: return "doc.on.doc.fill"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .added: return "追加"
+        case .modified: return "変更"
+        case .deleted: return "削除"
+        case .renamed: return "名前変更"
+        case .copied: return "コピー"
+        }
+    }
+}
+
+// MARK: - Diff Line
+
+/// 差分の1行
+struct DiffLine: Identifiable {
+    let id = UUID()
+    let lineNumber: Int?
+    let content: String
+    let type: DiffLineType
+}
+
+/// 差分行のタイプ
+enum DiffLineType {
+    case context    // 変更なし
+    case added      // 追加
+    case deleted    // 削除
+    case header     // ヘッダー（@@など）
+    case meta       // メタ情報
+
+    var color: Color {
+        switch self {
+        case .context: return .primary
+        case .added: return .green
+        case .deleted: return .red
+        case .header: return .cyan
+        case .meta: return .secondary
+        }
+    }
+
+    var backgroundColor: Color {
+        switch self {
+        case .added: return .green.opacity(0.15)
+        case .deleted: return .red.opacity(0.15)
+        default: return .clear
+        }
+    }
+}
+
+// MARK: - Diff Parser
+
+/// 差分パーサー
+struct DiffParser {
+    /// 差分文字列をパースして行の配列に変換
+    static func parse(_ diffString: String) -> [DiffLine] {
+        let lines = diffString.components(separatedBy: "\n")
+        var result: [DiffLine] = []
+        var lineNumber = 0
+
+        for line in lines {
+            let type: DiffLineType
+            let content: String
+
+            if line.hasPrefix("@@") {
+                type = .header
+                content = line
+                // 行番号をリセット
+                if let range = line.range(of: #"\+(\d+)"#, options: .regularExpression) {
+                    lineNumber = Int(line[range].dropFirst()) ?? 0
+                }
+            } else if line.hasPrefix("+++") || line.hasPrefix("---") {
+                type = .meta
+                content = line
+            } else if line.hasPrefix("diff ") || line.hasPrefix("index ") {
+                type = .meta
+                content = line
+            } else if line.hasPrefix("+") {
+                type = .added
+                content = String(line.dropFirst())
+                lineNumber += 1
+            } else if line.hasPrefix("-") {
+                type = .deleted
+                content = String(line.dropFirst())
+            } else if line.hasPrefix(" ") {
+                type = .context
+                content = String(line.dropFirst())
+                lineNumber += 1
+            } else {
+                type = .context
+                content = line
+                if !line.isEmpty {
+                    lineNumber += 1
+                }
+            }
+
+            result.append(DiffLine(
+                lineNumber: type == .context || type == .added ? lineNumber : nil,
+                content: content,
+                type: type
+            ))
+        }
+
+        return result
+    }
+}
+
+// MARK: - Diff Context
+
+/// 差分ビューアのコンテキスト
+class DiffContext: ObservableObject {
+    let repository: Repository
+    let commits: [Commit]  // 1つまたは2つ
+    let sourcePath: URL
+
+    @Published var changedFiles: [ChangedFile] = []
+    @Published var fileTree: [FileTreeNode] = []
+    @Published var selectedFilePath: String?
+    @Published var diffLines: [DiffLine] = []
+    @Published var fileContent: String = ""
+    @Published var isLoading = false
+    @Published var isLoadingTree = false
+    @Published var showDiff: Bool  // true=差分, false=ファイル全体
+
+    /// 閲覧モードかどうか（差分表示なし）
+    let browseMode: Bool
+
+    /// シングルコミットモードかどうか
+    var isSingleCommit: Bool {
+        commits.count == 1
+    }
+
+    /// 表示用タイトル
+    var title: String {
+        if browseMode {
+            return "ファイル閲覧: \(commits[0].shortSHA)"
+        }
+        if isSingleCommit {
+            return commits[0].shortSHA
+        } else {
+            return "\(commits[0].shortSHA)..\(commits[1].shortSHA)"
+        }
+    }
+
+    /// 対象のSHA（差分取得用）
+    var targetSHA: String {
+        isSingleCommit ? commits[0].sha : commits[1].sha
+    }
+
+    init(repository: Repository, commits: [Commit], browseMode: Bool = false) {
+        self.repository = repository
+        self.commits = commits
+        self.browseMode = browseMode
+        self.showDiff = !browseMode  // 閲覧モードの場合はデフォルトでファイル全体表示
+        self.sourcePath = AppSettings.shared.repositorySourceURL(
+            owner: repository.owner,
+            name: repository.name
+        )
+    }
+
+    /// ファイルツリーと変更ファイル一覧を読み込む
+    @MainActor
+    func loadFileTree() async {
+        isLoadingTree = true
+        defer { isLoadingTree = false }
+
+        do {
+            // 変更ファイル一覧を取得
+            if isSingleCommit {
+                changedFiles = try await GitService.shared.getChangedFiles(
+                    sha: commits[0].sha,
+                    at: sourcePath
+                )
+            } else {
+                changedFiles = try await GitService.shared.getChangedFilesBetween(
+                    from: commits[0].sha,
+                    to: commits[1].sha,
+                    at: sourcePath
+                )
+            }
+
+            // 全ファイルパスを取得
+            var allPaths = try await GitService.shared.getAllFilePaths(
+                sha: targetSHA,
+                at: sourcePath
+            )
+
+            // 削除されたファイルはls-treeに含まれないため、追加する
+            let deletedPaths = changedFiles
+                .filter { $0.status == .deleted }
+                .map { $0.path }
+            allPaths.append(contentsOf: deletedPaths)
+
+            // ツリーを構築
+            fileTree = FileTreeNode.buildTree(from: allPaths, changedFiles: changedFiles)
+
+        } catch {
+            print("[DiffContext] ファイルツリー取得エラー: \(error)")
+        }
+    }
+
+    /// ファイルを選択して内容を読み込む
+    @MainActor
+    func selectFile(path: String) async {
+        selectedFilePath = path
+        isLoading = true
+        defer { isLoading = false }
+
+        // 変更ファイルかどうかチェック
+        let changedFile = changedFiles.first { $0.path == path }
+
+        do {
+            if let changedFile = changedFile {
+                // 変更ファイルの場合: 差分を取得
+                let diffString: String
+                if isSingleCommit {
+                    diffString = try await GitService.shared.getFileDiff(
+                        sha: commits[0].sha,
+                        filePath: path,
+                        at: sourcePath
+                    )
+                } else {
+                    diffString = try await GitService.shared.getFileDiffBetween(
+                        from: commits[0].sha,
+                        to: commits[1].sha,
+                        filePath: path,
+                        at: sourcePath
+                    )
+                }
+                diffLines = DiffParser.parse(diffString)
+
+                // 削除ファイルの場合は親コミットから取得
+                if changedFile.status == .deleted {
+                    // シングルコミットの場合は親SHA、比較の場合はfromSHA
+                    let parentSHA = isSingleCommit ? commits[0].parentSHAs.first : commits[0].sha
+                    if let sha = parentSHA {
+                        fileContent = try await GitService.shared.getFileContent(
+                            sha: sha,
+                            filePath: path,
+                            at: sourcePath
+                        )
+                    } else {
+                        fileContent = "(削除前のファイル内容を取得できません)"
+                    }
+                } else {
+                    fileContent = try await GitService.shared.getFileContent(
+                        sha: targetSHA,
+                        filePath: path,
+                        at: sourcePath
+                    )
+                }
+            } else {
+                // 変更なしファイル: ファイル全体のみ取得
+                diffLines = []
+                fileContent = try await GitService.shared.getFileContent(
+                    sha: targetSHA,
+                    filePath: path,
+                    at: sourcePath
+                )
+            }
+        } catch {
+            print("[DiffContext] ファイル読み込みエラー: \(error)")
+            diffLines = []
+            fileContent = "エラー: \(error.localizedDescription)"
+        }
+    }
+
+    /// 選択中のファイルの変更ステータス
+    var selectedFileChangeStatus: ChangeStatus? {
+        guard let path = selectedFilePath else { return nil }
+        return changedFiles.first { $0.path == path }?.status
+    }
+}

--- a/GitTale/Views/DiffViewerView.swift
+++ b/GitTale/Views/DiffViewerView.swift
@@ -1,0 +1,674 @@
+//
+//  DiffViewerView.swift
+//  GitTale
+//
+//  Created by ogatomo83 on 2026/01/12.
+//
+
+import SwiftUI
+import AppKit
+
+// MARK: - Diff Viewer View
+
+struct DiffViewerView: View {
+    @StateObject var context: DiffContext
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // 左: ファイルツリー（固定幅）
+            FileTreeSidebarView(context: context)
+                .frame(width: 280)
+
+            Divider()
+
+            // 右: エディタビュー（残り全体）
+            EditorAreaView(context: context)
+                .frame(maxWidth: .infinity)
+        }
+        .frame(minWidth: 900, minHeight: 600)
+        .navigationTitle("差分: \(context.title)")
+        .task {
+            await context.loadFileTree()
+        }
+    }
+}
+
+// MARK: - File Tree Sidebar View
+
+struct FileTreeSidebarView: View {
+    @ObservedObject var context: DiffContext
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // ヘッダー: エクスプローラー
+            HStack {
+                Text("エクスプローラー")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(EditorColors.lineNumber)
+                    .textCase(.uppercase)
+                Spacer()
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(EditorColors.sidebar)
+
+            // リポジトリ名ヘッダー
+            HStack(spacing: 4) {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 10))
+                    .foregroundStyle(EditorColors.lineNumber)
+                Text(context.repository.name.uppercased())
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(EditorColors.text)
+                Spacer()
+                // 変更ファイル数バッジ
+                if !context.changedFiles.isEmpty {
+                    Text("\(context.changedFiles.count)")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundStyle(EditorColors.text)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.accentColor.opacity(0.3))
+                        .clipShape(Capsule())
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(EditorColors.sidebar.opacity(0.8))
+
+            // ファイルツリー
+            if context.isLoadingTree {
+                VStack {
+                    Spacer()
+                    ProgressView()
+                        .tint(EditorColors.text)
+                    Text("ファイルツリーを読み込み中...")
+                        .font(.caption)
+                        .foregroundStyle(EditorColors.lineNumber)
+                    Spacer()
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(EditorColors.sidebar)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 0) {
+                        ForEach(context.fileTree) { node in
+                            FileTreeNodeView(
+                                node: node,
+                                selectedPath: context.selectedFilePath,
+                                depth: 0
+                            ) { path in
+                                Task {
+                                    await context.selectFile(path: path)
+                                }
+                            }
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+                .background(EditorColors.sidebar)
+            }
+        }
+        .background(EditorColors.sidebar)
+    }
+}
+
+// MARK: - File Tree Node View
+
+struct FileTreeNodeView: View {
+    @ObservedObject var node: FileTreeNode
+    let selectedPath: String?
+    let depth: Int
+    let onSelect: (String) -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            // ノード行
+            HStack(spacing: 4) {
+                // インデント
+                if depth > 0 {
+                    Spacer()
+                        .frame(width: CGFloat(depth) * 16)
+                }
+
+                // 展開アイコン（ディレクトリのみ）
+                if node.isDirectory {
+                    Image(systemName: node.isExpanded ? "chevron.down" : "chevron.right")
+                        .font(.system(size: 10))
+                        .foregroundStyle(EditorColors.lineNumber)
+                        .frame(width: 12)
+                } else {
+                    Spacer()
+                        .frame(width: 12)
+                }
+
+                // ファイル/フォルダアイコン
+                Image(systemName: node.isDirectory ? (node.isExpanded ? "folder.fill" : "folder") : fileIcon(for: node.name))
+                    .font(.system(size: 14))
+                    .foregroundStyle(iconColor)
+                    .frame(width: 18)
+
+                // ファイル名
+                Text(node.name)
+                    .font(.system(size: 13))
+                    .foregroundStyle(textColor)
+                    .lineLimit(1)
+
+                Spacer()
+
+                // 変更ステータスインジケーター
+                if let status = node.changeStatus {
+                    Text(statusLetter(for: status))
+                        .font(.system(size: 11, weight: .medium, design: .monospaced))
+                        .foregroundStyle(status.color)
+                        .frame(width: 16)
+                }
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(rowBackground)
+            .contentShape(Rectangle())
+            .onHover { hovering in
+                isHovered = hovering
+            }
+            .onTapGesture {
+                if node.isDirectory {
+                    withAnimation(.easeInOut(duration: 0.15)) {
+                        node.isExpanded.toggle()
+                    }
+                } else {
+                    onSelect(node.path)
+                }
+            }
+
+            // 子ノード（展開時）
+            if node.isDirectory && node.isExpanded {
+                ForEach(node.children) { child in
+                    FileTreeNodeView(
+                        node: child,
+                        selectedPath: selectedPath,
+                        depth: depth + 1,
+                        onSelect: onSelect
+                    )
+                }
+            }
+        }
+    }
+
+    /// 行の背景色
+    private var rowBackground: Color {
+        if selectedPath == node.path && !node.isDirectory {
+            return EditorColors.selectedLine
+        }
+        if isHovered {
+            return EditorColors.hoverLine
+        }
+        return .clear
+    }
+
+    /// アイコンの色
+    private var iconColor: Color {
+        if node.isDirectory {
+            return node.hasChangedDescendant ? Color.yellow : Color(red: 0.557, green: 0.757, blue: 0.906)  // VSCode folder blue
+        }
+        if let status = node.changeStatus {
+            return status.color
+        }
+        return EditorColors.text.opacity(0.7)
+    }
+
+    /// テキストの色
+    private var textColor: Color {
+        if let status = node.changeStatus {
+            return status.color
+        }
+        return EditorColors.text
+    }
+
+    /// ファイル拡張子に応じたアイコン
+    private func fileIcon(for filename: String) -> String {
+        let ext = (filename as NSString).pathExtension.lowercased()
+        switch ext {
+        case "swift": return "swift"
+        case "js", "jsx": return "curlybraces"
+        case "ts", "tsx": return "curlybraces"
+        case "py": return "chevron.left.forwardslash.chevron.right"
+        case "rb": return "diamond.fill"
+        case "go": return "chevron.left.forwardslash.chevron.right"
+        case "rs": return "gearshape.fill"
+        case "java", "kt": return "cup.and.saucer.fill"
+        case "c", "cpp", "h", "hpp": return "c.square.fill"
+        case "cs": return "number.square.fill"
+        case "html", "htm": return "globe"
+        case "css", "scss", "sass": return "paintpalette.fill"
+        case "json": return "curlybraces.square.fill"
+        case "xml": return "chevron.left.forwardslash.chevron.right"
+        case "yml", "yaml": return "list.bullet.rectangle"
+        case "md", "markdown": return "doc.text"
+        case "txt": return "doc.plaintext"
+        case "sh", "bash", "zsh": return "terminal.fill"
+        case "sql": return "cylinder.fill"
+        case "png", "jpg", "jpeg", "gif", "svg", "ico": return "photo"
+        case "pdf": return "doc.fill"
+        case "zip", "tar", "gz", "rar": return "doc.zipper"
+        case "gitignore", "gitattributes": return "arrow.triangle.branch"
+        case "dockerfile": return "shippingbox.fill"
+        case "lock": return "lock.fill"
+        default: return "doc"
+        }
+    }
+
+    /// ステータス文字
+    private func statusLetter(for status: ChangeStatus) -> String {
+        switch status {
+        case .added: return "A"
+        case .modified: return "M"
+        case .deleted: return "D"
+        case .renamed: return "R"
+        case .copied: return "C"
+        }
+    }
+}
+
+// MARK: - Editor Area View
+
+struct EditorAreaView: View {
+    @ObservedObject var context: DiffContext
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // タブバー
+            EditorTabBarView(context: context)
+
+            // コンテンツ
+            if context.selectedFilePath == nil {
+                // ファイル未選択
+                VStack(spacing: 16) {
+                    Image(systemName: "doc.text.magnifyingglass")
+                        .font(.system(size: 48))
+                        .foregroundStyle(EditorColors.lineNumber)
+                    Text("ファイルを選択してください")
+                        .font(.headline)
+                        .foregroundStyle(EditorColors.text)
+                    Text("左のファイルツリーからファイルを選択すると内容が表示されます")
+                        .font(.subheadline)
+                        .foregroundStyle(EditorColors.lineNumber)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(EditorColors.background)
+            } else if context.isLoading {
+                // 読み込み中
+                VStack {
+                    ProgressView()
+                        .tint(EditorColors.text)
+                    Text("読み込み中...")
+                        .font(.caption)
+                        .foregroundStyle(EditorColors.lineNumber)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(EditorColors.background)
+            } else if !context.browseMode && context.showDiff && !context.diffLines.isEmpty {
+                // 差分表示（閲覧モードでは表示しない）
+                DiffLinesView(lines: context.diffLines)
+            } else {
+                // ファイル全体表示
+                FileContentView(content: context.fileContent)
+            }
+        }
+        .background(EditorColors.background)
+    }
+}
+
+// MARK: - Editor Tab Bar View
+
+struct EditorTabBarView: View {
+    @ObservedObject var context: DiffContext
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // ファイルタブ
+            if let path = context.selectedFilePath {
+                HStack(spacing: 8) {
+                    // ファイルアイコン
+                    Image(systemName: fileIcon(for: (path as NSString).lastPathComponent))
+                        .font(.system(size: 14))
+                        .foregroundStyle(EditorColors.text.opacity(0.7))
+
+                    // ファイル名
+                    Text((path as NSString).lastPathComponent)
+                        .font(.system(size: 13))
+                        .foregroundStyle(EditorColors.text)
+                        .lineLimit(1)
+
+                    // 変更ステータス
+                    if let status = context.selectedFileChangeStatus {
+                        Text(statusLetter(for: status))
+                            .font(.system(size: 11, weight: .medium, design: .monospaced))
+                            .foregroundStyle(status.color)
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(EditorColors.background)
+                .overlay(
+                    Rectangle()
+                        .fill(Color.accentColor)
+                        .frame(height: 2),
+                    alignment: .bottom
+                )
+            }
+
+            Spacer()
+
+            // 表示切り替え（変更ファイルのみ、閲覧モードでは非表示）
+            if !context.browseMode && context.selectedFileChangeStatus != nil {
+                HStack(spacing: 4) {
+                    TabButton(title: "差分", isSelected: context.showDiff) {
+                        context.showDiff = true
+                    }
+                    TabButton(title: "全体", isSelected: !context.showDiff) {
+                        context.showDiff = false
+                    }
+                }
+                .padding(.trailing, 12)
+            }
+        }
+        .frame(height: 36)
+        .background(EditorColors.tabBar)
+    }
+
+    private func fileIcon(for filename: String) -> String {
+        let ext = (filename as NSString).pathExtension.lowercased()
+        switch ext {
+        case "swift": return "swift"
+        case "rb": return "diamond.fill"
+        case "js", "ts", "jsx", "tsx": return "curlybraces"
+        case "py": return "chevron.left.forwardslash.chevron.right"
+        case "html", "htm": return "globe"
+        case "css", "scss": return "paintpalette.fill"
+        case "json": return "curlybraces.square.fill"
+        case "md": return "doc.text"
+        case "yml", "yaml": return "list.bullet.rectangle"
+        default: return "doc"
+        }
+    }
+
+    private func statusLetter(for status: ChangeStatus) -> String {
+        switch status {
+        case .added: return "A"
+        case .modified: return "M"
+        case .deleted: return "D"
+        case .renamed: return "R"
+        case .copied: return "C"
+        }
+    }
+}
+
+// MARK: - Tab Button
+
+struct TabButton: View {
+    let title: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 12))
+                .foregroundStyle(isSelected ? EditorColors.text : EditorColors.lineNumber)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 4)
+                .background(isSelected ? EditorColors.background : Color.clear)
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Diff Lines View
+
+struct DiffLinesView: View {
+    let lines: [DiffLine]
+    @State private var hoveredLineId: UUID?
+
+    var body: some View {
+        GeometryReader { geometry in
+            ScrollView([.horizontal, .vertical]) {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(lines) { line in
+                        DiffLineRowView(
+                            line: line,
+                            minWidth: geometry.size.width,
+                            isHovered: hoveredLineId == line.id
+                        )
+                        .onHover { isHovered in
+                            hoveredLineId = isHovered ? line.id : nil
+                        }
+                    }
+                }
+            }
+        }
+        .font(.system(size: 13, weight: .regular, design: .monospaced))
+        .background(EditorColors.background)
+    }
+}
+
+// MARK: - Diff Line Row View
+
+struct DiffLineRowView: View {
+    let line: DiffLine
+    let minWidth: CGFloat
+    let isHovered: Bool
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // ガター（行番号エリア）
+            HStack(spacing: 0) {
+                // 行番号
+                Text(line.lineNumber.map { String($0) } ?? "")
+                    .frame(width: 48, alignment: .trailing)
+                    .foregroundStyle(EditorColors.lineNumber)
+
+                // 差分記号
+                Text(diffSymbol)
+                    .frame(width: 20, alignment: .center)
+                    .foregroundStyle(diffSymbolColor)
+            }
+            .padding(.trailing, 8)
+            .background(gutterBackground)
+
+            // コード内容
+            Text(line.content.isEmpty ? " " : line.content)
+                .foregroundStyle(line.type == .context ? EditorColors.text : line.type.color)
+                .textSelection(.enabled)
+                .padding(.leading, 8)
+        }
+        .frame(height: 22)
+        .frame(minWidth: minWidth, alignment: .leading)
+        .background(lineBackground)
+    }
+
+    private var diffSymbol: String {
+        switch line.type {
+        case .added: return "+"
+        case .deleted: return "−"
+        default: return ""
+        }
+    }
+
+    private var diffSymbolColor: Color {
+        switch line.type {
+        case .added: return EditorColors.addedText
+        case .deleted: return EditorColors.deletedText
+        default: return .clear
+        }
+    }
+
+    private var gutterBackground: Color {
+        switch line.type {
+        case .added: return EditorColors.addedGutter
+        case .deleted: return EditorColors.deletedGutter
+        default: return EditorColors.gutter
+        }
+    }
+
+    private var lineBackground: Color {
+        if isHovered {
+            return EditorColors.hoverLine
+        }
+        switch line.type {
+        case .added: return EditorColors.addedLine
+        case .deleted: return EditorColors.deletedLine
+        default: return .clear
+        }
+    }
+}
+
+// MARK: - File Content View
+
+struct FileContentView: View {
+    let content: String
+
+    var body: some View {
+        HStack(spacing: 0) {
+            // 行番号ガター
+            LineNumberGutter(content: content)
+
+            // コード内容（選択可能）
+            SelectableCodeView(content: content)
+        }
+        .background(EditorColors.background)
+    }
+}
+
+// MARK: - Line Number Gutter
+
+struct LineNumberGutter: View {
+    let content: String
+
+    private var lineCount: Int {
+        content.components(separatedBy: "\n").count
+    }
+
+    var body: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            VStack(alignment: .trailing, spacing: 0) {
+                ForEach(1...max(lineCount, 1), id: \.self) { lineNumber in
+                    Text("\(lineNumber)")
+                        .font(.system(size: 13, design: .monospaced))
+                        .foregroundStyle(EditorColors.lineNumber)
+                        .frame(height: 20)
+                }
+            }
+            .padding(.horizontal, 8)
+        }
+        .frame(width: 56)
+        .background(EditorColors.gutter)
+        .disabled(true)  // ガターはスクロール連動のみ
+    }
+}
+
+// MARK: - Selectable Code View (NSTextView wrapper)
+
+struct SelectableCodeView: NSViewRepresentable {
+    let content: String
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        let textView = NSTextView()
+
+        // テキストビュー設定
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.backgroundColor = NSColor(EditorColors.background)
+        textView.textColor = NSColor(EditorColors.text)
+        textView.font = NSFont.monospacedSystemFont(ofSize: 13, weight: .regular)
+        textView.textContainerInset = NSSize(width: 8, height: 4)
+        textView.isAutomaticQuoteSubstitutionEnabled = false
+        textView.isAutomaticDashSubstitutionEnabled = false
+        textView.isAutomaticTextReplacementEnabled = false
+
+        // 行の高さ設定
+        textView.defaultParagraphStyle = {
+            let style = NSMutableParagraphStyle()
+            style.lineSpacing = 0
+            style.minimumLineHeight = 20
+            style.maximumLineHeight = 20
+            return style
+        }()
+
+        // スクロールビュー設定
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.documentView = textView
+        scrollView.backgroundColor = NSColor(EditorColors.background)
+
+        // 横スクロール対応
+        textView.isHorizontallyResizable = true
+        textView.textContainer?.widthTracksTextView = false
+        textView.textContainer?.containerSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        guard let textView = scrollView.documentView as? NSTextView else { return }
+        if textView.string != content {
+            textView.string = content
+        }
+    }
+}
+
+// MARK: - Editor Colors (VSCode Dark+ Theme)
+
+struct EditorColors {
+    // 背景色
+    static let background = Color(red: 0.118, green: 0.118, blue: 0.118)  // #1e1e1e
+    static let gutter = Color(red: 0.118, green: 0.118, blue: 0.118)  // #1e1e1e
+    static let tabBar = Color(red: 0.149, green: 0.149, blue: 0.149)  // #262626
+    static let sidebar = Color(red: 0.149, green: 0.149, blue: 0.149)  // #262626
+
+    // テキスト色
+    static let text = Color(red: 0.847, green: 0.847, blue: 0.847)  // #d4d4d4
+    static let lineNumber = Color(red: 0.522, green: 0.522, blue: 0.522)  // #858585
+    static let lineNumberHover = Color(red: 0.769, green: 0.769, blue: 0.769)  // #c4c4c4
+
+    // ホバー・選択
+    static let hoverLine = Color(red: 0.173, green: 0.173, blue: 0.173)  // #2c2c2c
+    static let selectedLine = Color(red: 0.039, green: 0.227, blue: 0.424)  // #0a3a6c
+
+    // 差分色（追加）
+    static let addedLine = Color(red: 0.157, green: 0.235, blue: 0.173)  // #283b2c
+    static let addedGutter = Color(red: 0.118, green: 0.314, blue: 0.196)  // #1e5032
+    static let addedText = Color(red: 0.522, green: 0.863, blue: 0.522)  // #85dc85
+
+    // 差分色（削除）
+    static let deletedLine = Color(red: 0.275, green: 0.157, blue: 0.157)  // #462828
+    static let deletedGutter = Color(red: 0.392, green: 0.157, blue: 0.157)  // #642828
+    static let deletedText = Color(red: 0.949, green: 0.522, blue: 0.522)  // #f28585
+}
+
+#Preview {
+    DiffViewerView(
+        context: DiffContext(
+            repository: Repository(
+                owner: "rails",
+                name: "rails",
+                url: "https://github.com/rails/rails.git"
+            ),
+            commits: [
+                Commit(
+                    sha: "abc123",
+                    shortSHA: "abc123",
+                    author: "Test",
+                    email: "test@test.com",
+                    date: Date(),
+                    message: "Test commit",
+                    parentSHAs: []
+                )
+            ]
+        )
+    )
+}


### PR DESCRIPTION
## Summary
- コミットの差分を表示するビューア機能を実装
- VSCodeライクなファイルツリーでリポジトリ全体のファイルを閲覧可能
- 差分ビュー/ファイル全体ビューの切り替え機能
- チェックアウト状態の永続化（アプリ再起動後も保持）
- ダブルクリックでのチェックアウト機能
- VSCode Dark+テーマに準拠したエディタUI
- 複数行テキスト選択に対応

## Changes
- `GitTale/Models/Diff.swift` - 差分モデル、ファイルツリー、パーサー
- `GitTale/Views/DiffViewerView.swift` - 差分ビューアUI
- `GitTale/Views/CommitTimelineView.swift` - タイムラインからの連携
- `GitTale/Services/GitService.swift` - Git差分関連コマンド追加
- `GitTale/Models/Commit.swift` - チェックアウト状態の永続化
- `GitTale/GitTaleApp.swift` - 差分ビューアウィンドウ定義

## Test plan
- [ ] コミット行をダブルクリックでチェックアウトできる
- [ ] 「差分を表示」ボタンで差分ビューアが開く
- [ ] 「ファイルを見る」ボタンでファイル閲覧モードで開く
- [ ] ファイルツリーでディレクトリを展開/折りたたみできる
- [ ] 変更ファイルにステータスアイコン（追加/変更/削除）が表示される
- [ ] 差分ビュー/ファイル全体ビューを切り替えできる
- [ ] コードエディタで複数行選択ができる
- [ ] アプリを再起動してもチェックアウト状態が保持される

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)